### PR TITLE
Replace `set-output` command

### DIFF
--- a/token_getter.py
+++ b/token_getter.py
@@ -149,4 +149,4 @@ if __name__ == '__main__':
     assert token, 'Token not returned!'
 
     print(f"::add-mask::{token}")
-    print(f"::set-output name=app_token::{token}")
+    print(f"app_token={token} >> $GITHUB_OUTPUT")


### PR DESCRIPTION
The current [`token_getter.py` script, on line 152](https://github.com/elastic/actions-app-token/blob/master/token_getter.py#L152) has:
```python
    print(f"::set-output name=app_token::{token}")
```

This is using the deprecated `set-output` command:
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR replaces the `set-output` command as updated in [the `Ezzahhh/actions-app-token` repo](https://github.com/Ezzahhh/actions-app-token/commit/244b1e2aa2906aa403cd9ece4293a1a51c0ed577#diff-a2ea2659e2f5c2958310dda22ecf06b30ac9a2a7d708da4d686aee8572bd3770) with:
```python
    print(f"app_token={token} >> $GITHUB_OUTPUT")
```