### PR TITLE
replace deprecated set-output

### DIFF
--- a/token_getter.py
+++ b/token_getter.py
@@ -149,4 +149,5 @@ if __name__ == '__main__':
     assert token, 'Token not returned!'
 
     print(f"::add-mask::{token}")
-    print(f"::set-output name=app_token::{token}")
+    with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
+        f.write("app_token={}\n".format(token))


### PR DESCRIPTION
I've just found that this action uses a deprecated function. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

For the record, https://github.com/orgs/community/discussions/28146#discussioncomment-4110404 explains how to replace it